### PR TITLE
Fix installation with catkin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,38 +1,54 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(livox_laser_simulation)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
 add_compile_options(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  tf
+    gazebo_ros
+    roscpp
+    tf
 )
 
+include_directories(include ${catkin_INCLUDE_DIRS})
+
+## Find gazebo
+if(POLICY CMP0054)
+    cmake_policy(SET CMP0054 NEW)
+endif()
 find_package(gazebo REQUIRED)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GAZEBO_CXX_FLAGS}")
+link_directories(${GAZEBO_LIBRARY_DIRS})
 include_directories(${GAZEBO_INCLUDE_DIRS})
 
-#To solve the error which gazebo does not handle the include file well, we must add this line.
-include_directories(/usr/include/gazebo-7/gazebo)
-
-link_directories(${GAZEBO_LIBRARY_DIRS})
-
-#This is designed for whose proto installed in system is not 2.6. We can install the version of proto in local dir
-#include_directories(/home/lfc/proto/include/)
-#link_directories(/home/lfc/proto/lib/)
-
-include_directories(
-         include
-        ${catkin_INCLUDE_DIRS}
-)
-
 catkin_package(
-        INCLUDE_DIRS include
-        LIBRARIES livox_laser_simulation
-        CATKIN_DEPENDS tf
+    INCLUDE_DIRS include
+    LIBRARIES livox_laser_simulation
+    CATKIN_DEPENDS tf
 )
 
 add_library(livox_laser_simulation SHARED src/livox_points_plugin.cpp src/livox_ode_multiray_shape.cpp)
-target_link_libraries(livox_laser_simulation ${catkin_LIBRARIES} RayPlugin)
+target_link_libraries(livox_laser_simulation ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES} RayPlugin)
 
-target_link_libraries(livox_laser_simulation libprotobuf.so.9)
+install(DIRECTORY include/${PROJECT_NAME}/
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+    FILES_MATCHING PATTERN "*.h"
+    PATTERN ".svn" EXCLUDE
+)
+
+install(TARGETS livox_laser_simulation
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
+
+install(DIRECTORY
+        launch
+        meshes
+        resources
+        rviz
+        scan_mode
+        urdf
+        worlds
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/include/livox_laser_simulation/livox_ode_multiray_shape.h
+++ b/include/livox_laser_simulation/livox_ode_multiray_shape.h
@@ -7,7 +7,7 @@
 #include <gazebo/physics/MultiRayShape.hh>
 #include <gazebo/util/system.hh>
 #include <gazebo/ode/common.h>
-#include <ignition/math4/ignition/math.hh>
+#include <ignition/math/Vector3.hh>
 
 namespace gazebo{
 namespace physics{

--- a/package.xml
+++ b/package.xml
@@ -1,62 +1,25 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>livox_laser_simulation</name>
   <version>0.0.0</version>
   <description>The livox_laser_simulation package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="lfc@todo.todo">lfc</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>TODO</license>
 
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/livox_laser_simulation</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>gazebo</build_depend>
+  <build_depend>gazebo_ros</build_depend>
   <build_depend>tf</build_depend>
+
+  <build_export_depend>gazebo</build_export_depend>
+  <build_export_depend>gazebo_ros</build_export_depend>
   <build_export_depend>tf</build_export_depend>
+
+  <exec_depend>gazebo</exec_depend>
+  <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>tf</exec_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>

--- a/src/livox_ode_multiray_shape.cpp
+++ b/src/livox_ode_multiray_shape.cpp
@@ -12,7 +12,7 @@
 #include <gazebo/physics/ode/ODERayShape.hh>
 #include <gazebo/physics/ode/ODEMultiRayShape.hh>
 #include "livox_laser_simulation/livox_ode_multiray_shape.h"
-#include <ignition/math4/ignition/math.hh>
+#include <ignition/math/Vector3.hh>
 
 using namespace gazebo;
 using namespace physics;


### PR DESCRIPTION
The package does not install some resources properly hence the command `catkin_make install` won't work as expected. This PR makes the changes to make it work (and compile with newer versions of Gazebo too).

Signed-off-by: Emiliano Borghi <emiliano@smartmachine.nz>